### PR TITLE
Support multiple repositories in the branches command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Commands/__pycache__
 Lib/__pycache__
+__pycache__

--- a/Commands/branches.py
+++ b/Commands/branches.py
@@ -2,6 +2,7 @@ from Commands.command import Command
 from Lib.termcolor import colored
 import git
 import json
+import os
 import re
 import subprocess
 
@@ -10,12 +11,87 @@ class Branches(Command):
     def configure(self):
         self.name = "branches";
         self.description = "show local branches with GitHub issue/PR status.";
+        self.config = "branches";
+
+    def hasAllFlag(self, args):
+        return '--all' in args
+
+    def buildRepoMap(self, config):
+        default = config['DEFAULT']
+        raw = default.get('list', '')
+        repo_map = {}
+        if not raw:
+            return repo_map
+        for name in raw.split(','):
+            name = name.strip()
+            if not name:
+                continue
+            path = default.get(name)
+            if not path:
+                continue
+            repo_map[name] = os.path.expanduser(path.strip())
+        return repo_map
+
+    def printEmptyListMessage(self):
+        print('No repositories configured.')
+        print('Add repositories to ' + colored('config/branches/conf', 'yellow') +
+              ' to use this feature.')
+        print('See config/branches/conf.default for the expected format.')
+
+    def promptForRepo(self, repo_map):
+        from simple_term_menu import TerminalMenu
+
+        names = list(repo_map.keys())
+        menu = TerminalMenu(names, title='Select a repository:')
+        index = menu.show()
+        if index is None:
+            return None, None
+        name = names[index]
+        return name, repo_map[name]
 
     def handle(self, args):
-        repo = git.Repo(search_parent_directories=True)
+        if self.hasAllFlag(args):
+            repo_map = self.buildRepoMap(self.getConfig())
+            if not repo_map:
+                self.printEmptyListMessage()
+                return
+            for name, path in repo_map.items():
+                print(colored(name, 'yellow'))
+                self.reportRepoSafely(path)
+                print()
+            return
+
+        try:
+            self.reportRepo()
+        except git.InvalidGitRepositoryError:
+            repo_map = self.buildRepoMap(self.getConfig())
+            if not repo_map:
+                self.printEmptyListMessage()
+                return
+            name, path = self.promptForRepo(repo_map)
+            if not path:
+                return
+            print(colored(name, 'yellow'))
+            self.reportRepoSafely(path)
+
+    def reportRepoSafely(self, path):
+        try:
+            self.reportRepo(path)
+        except git.InvalidGitRepositoryError:
+            print('  ' + colored('not a git repository: ' + path, 'red'))
+        except git.NoSuchPathError:
+            print('  ' + colored('path does not exist: ' + path, 'red'))
+
+    def reportRepo(self, repo_path=None):
+        if repo_path:
+            repo = git.Repo(repo_path, search_parent_directories=True)
+        else:
+            repo = git.Repo(search_parent_directories=True)
+
+        cwd = repo.working_tree_dir
         branches = sorted([h.name for h in repo.heads])
 
-        prs = self.fetchPRs()
+        prs = self.fetchPRs(cwd)
         pr_by_branch = {}
         for pr in prs:
             pr_by_branch[pr['headRefName']] = pr
@@ -32,7 +108,7 @@ class Branches(Command):
 
             if match:
                 issue_number = match.group(1)
-                issue = self.fetchIssue(issue_number)
+                issue = self.fetchIssue(issue_number, cwd)
                 if issue:
                     issue_state = issue.get('state', '')
                     project_name, project_status = self.extractProject(issue)
@@ -46,14 +122,14 @@ class Branches(Command):
 
             rows.append((branch, issue_state, pr_number, pr_state, reviewers, project_name, project_status))
 
-        repo_url = self.getRepoUrl()
+        repo_url = self.getRepoUrl(cwd)
         self.printTable(rows, prs, repo_url)
 
-    def fetchPRs(self):
+    def fetchPRs(self, cwd=None):
         try:
             result = subprocess.run(
                 ['gh', 'pr', 'list', '--state', 'all', '--json', 'number,headRefName,state,latestReviews,reviewRequests', '-L', '100'],
-                stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False, cwd=cwd
             )
             if result.returncode == 0:
                 return json.loads(result.stdout.decode('utf-8'))
@@ -61,11 +137,11 @@ class Branches(Command):
             pass
         return []
 
-    def fetchIssue(self, number):
+    def fetchIssue(self, number, cwd=None):
         try:
             result = subprocess.run(
                 ['gh', 'issue', 'view', str(number), '--json', 'state,assignees,projectItems'],
-                stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False, cwd=cwd
             )
             if result.returncode == 0:
                 return json.loads(result.stdout.decode('utf-8'))
@@ -130,11 +206,11 @@ class Branches(Command):
 
         return ', '.join(parts)
 
-    def getRepoUrl(self):
+    def getRepoUrl(self, cwd=None):
         try:
             result = subprocess.run(
                 ['gh', 'repo', 'view', '--json', 'url', '-q', '.url'],
-                stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False, cwd=cwd
             )
             if result.returncode == 0:
                 return result.stdout.decode('utf-8').strip()

--- a/config/branches/conf.default
+++ b/config/branches/conf.default
@@ -1,0 +1,18 @@
+# This file will be overwritten with an update.
+# Create conf in this directory for your own settings.
+#
+# Configure the repositories the `branches` command can inspect.
+# Used when running `gizmo branches` outside a git repo (interactive
+# selection) and by `gizmo branches --all` (every repo in the list).
+#
+# Follow the same format as the health config: a comma-separated `list`
+# of names, plus a `<name> = <path>` entry per repository. Paths may use
+# `~` for your home directory.
+#
+#   [DEFAULT]
+#   list = web-app,web-api
+#   web-app = ~/repos/celery-web-app
+#   web-api = ~/repos/celery-web-api
+#
+[DEFAULT]
+list =

--- a/install.sh
+++ b/install.sh
@@ -3,10 +3,12 @@
 # Create directory
 mkdir -p ~/venvs/gizmo
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 cd ~/venvs/gizmo
 python3 -m venv venv/
 source venv/bin/activate
-pip3 install gitpython
+pip3 install -r "$SCRIPT_DIR/requirements.txt"
 
 deactivate
 echo "Run your program with:"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 gitpython
+simple-term-menu

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+# Make the project root importable so tests can `from Commands.branches import Branches`.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.realpath(__file__))))

--- a/tests/test_branches.py
+++ b/tests/test_branches.py
@@ -1,0 +1,72 @@
+import configparser
+import os
+
+from Commands.branches import Branches
+
+
+def makeConfig(text):
+    config = configparser.ConfigParser()
+    config.read_string(text)
+    return config
+
+
+class TestHasAllFlag:
+    def test_returns_true_when_all_flag_present(self):
+        assert Branches().hasAllFlag(['--all']) is True
+
+    def test_returns_false_when_no_args(self):
+        assert Branches().hasAllFlag([]) is False
+
+    def test_returns_false_for_other_args(self):
+        assert Branches().hasAllFlag(['something']) is False
+
+
+class TestBuildRepoMap:
+    def test_empty_list_returns_empty_map(self):
+        config = makeConfig("[DEFAULT]\nlist =\n")
+        assert Branches().buildRepoMap(config) == {}
+
+    def test_missing_list_returns_empty_map(self):
+        config = makeConfig("[DEFAULT]\n")
+        assert Branches().buildRepoMap(config) == {}
+
+    def test_maps_names_to_paths_preserving_order(self):
+        config = makeConfig(
+            "[DEFAULT]\n"
+            "list = web-app,web-api\n"
+            "web-app = /repos/celery-web-app\n"
+            "web-api = /repos/celery-web-api\n"
+        )
+        result = Branches().buildRepoMap(config)
+        assert list(result.items()) == [
+            ('web-app', '/repos/celery-web-app'),
+            ('web-api', '/repos/celery-web-api'),
+        ]
+
+    def test_expands_user_home_in_paths(self):
+        config = makeConfig(
+            "[DEFAULT]\n"
+            "list = web-app\n"
+            "web-app = ~/repos/celery-web-app\n"
+        )
+        result = Branches().buildRepoMap(config)
+        assert result['web-app'] == os.path.expanduser('~/repos/celery-web-app')
+
+    def test_ignores_whitespace_around_names(self):
+        config = makeConfig(
+            "[DEFAULT]\n"
+            "list = web-app , web-api\n"
+            "web-app = /a\n"
+            "web-api = /b\n"
+        )
+        result = Branches().buildRepoMap(config)
+        assert list(result.keys()) == ['web-app', 'web-api']
+
+    def test_skips_names_without_a_path(self):
+        config = makeConfig(
+            "[DEFAULT]\n"
+            "list = web-app,ghost\n"
+            "web-app = /a\n"
+        )
+        result = Branches().buildRepoMap(config)
+        assert result == {'web-app': '/a'}


### PR DESCRIPTION
## Summary

Extends the `branches` command to work across multiple repositories instead of
only the git repo it is invoked from:

- **Configurable repo list** — new `config/branches/conf.default` (empty by
  default, `health`-style format), with local overrides via the gitignored
  `config/branches/conf`.
- **Interactive selection** — when run outside a git repo, presents an
  arrow-key picker (`simple-term-menu`) of the configured repos.
- **`--all` flag** — `gizmo branches --all` reports every configured repo,
  each under its own header.
- **Friendly empty-list message** when the list is unconfigured.
- A bad/missing configured path degrades to a per-repo error instead of
  aborting the whole `--all` run.

Internally, the report logic moved into `reportRepo(path)` and all `gh`/git
calls now run against each target repo's working directory.

## Motivation and Context

closes #7

The command previously failed outside a git repo and could only inspect one
repository at a time. This makes it usable as a cross-repo branch overview.

## How Has This Been Tested

- New pytest suite (`tests/`) covering `--all` flag parsing and repo-map
  building (name→path, `~` expansion, ordering, empty/missing list) — 9 tests
  passing.
- Manual verification: in-repo (unchanged output), `--all` with empty list and
  with configured repos (per-repo headers + graceful error on a bad path), and
  the no-git-repo empty-list message.
- The interactive picker requires a TTY and was not exercised by automated
  tests.

## Types of Changes

- [x] New feature (non-breaking change which adds functionality)
- [x] Adds dependencies (`simple-term-menu` runtime; `pytest` dev)

## Checklist

- [x] Default config is tracked and empty; local `conf` stays gitignored
- [x] `install.sh` now installs from `requirements.txt`
- [x] Existing in-repo behavior preserved